### PR TITLE
Add GitHub Actions workflow to build VSIX package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build VS Code Extension
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Webview assets
+        run: pnpm run build:webview
+
+      - name: Compile extension
+        run: pnpm run compile
+
+      - name: Package VSIX
+        run: pnpm run vsix
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claudex-extension
+          path: "*.vsix"
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build VS Code Extension
 
 on:
   push:
-    branches: ["main"]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies with pnpm
- build the webview and extension code before packaging a VSIX file
- upload the generated VSIX package as a build artifact for verification

## Testing
- not run (workflow only)

------
https://chatgpt.com/codex/tasks/task_b_68e4ce67349c8331bb748875e156f59a