### PR TITLE
feat: migrate to Claude Agent SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Claudex
 
-Claudex - Claude Code for VSCode.
+Claudex - Claude Agent SDK for VSCode.
 
 Haleclipse

--- a/esbuild.js
+++ b/esbuild.js
@@ -39,7 +39,7 @@ const copyClaudeCliPlugin = {
         const require = createRequire(import.meta.url);
         build.onEnd(async () => {
             try {
-                const pkgDir = path.dirname(require.resolve('@anthropic-ai/claude-code/cli.js'));
+                const pkgDir = path.dirname(require.resolve('@anthropic-ai/claude-agent-sdk/cli.js'));
                 const outDir = path.resolve(process.cwd(), 'dist');
                 await fs.mkdir(outDir, { recursive: true });
 
@@ -47,7 +47,7 @@ const copyClaudeCliPlugin = {
                 const cliSrc = path.join(pkgDir, 'cli.js');
                 const cliDst = path.join(outDir, 'claude-cli.js');
                 await fs.copyFile(cliSrc, cliDst);
-                console.log(`[build] Copied Claude CLI -> ${path.relative(process.cwd(), cliDst)}`);
+                console.log(`[build] Copied Claude Agent CLI -> ${path.relative(process.cwd(), cliDst)}`);
 
                 // copy yoga.wasm (required by CLI at runtime)
                 const wasmSrc = path.join(pkgDir, 'yoga.wasm');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-claudex",
   "displayName": "Claudex",
-  "description": "Claude Code for VSCode.",
+  "description": "Claude Agent SDK for VSCode.",
   "version": "0.0.1",
   "publisher": "CometixSpace",
   "type": "module",
@@ -410,7 +410,7 @@
     "vue-tsc": "^3.0.8"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "^1.0.123",
+    "@anthropic-ai/claude-agent-sdk": "^0.1.9",
     "@anthropic-ai/sdk": "^0.63.1",
     "@mdi/font": "^7.4.47",
     "@modelcontextprotocol/sdk": "^1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@anthropic-ai/claude-code':
-        specifier: ^1.0.123
-        version: 1.0.128
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.1.9
+        version: 0.1.9
       '@anthropic-ai/sdk':
         specifier: ^0.63.1
         version: 0.63.1(zod@4.1.11)
@@ -105,10 +105,9 @@ importers:
 
 packages:
 
-  '@anthropic-ai/claude-code@1.0.128':
-    resolution: {integrity: sha512-uUg5cFMJfeQetQzFw76Vpbro6DAXst2Lpu8aoZWRFSoQVYu5ZSAnbBoxaWmW/IgnHSqIIvtMwzCoqmcA9j9rNQ==}
+  '@anthropic-ai/claude-agent-sdk@0.1.9':
+    resolution: {integrity: sha512-vQ1pJWGvc9f7qmfkgRoq/RUeqtXCbBE5jnn8zqXcY/nArZzL7nlwYQbsLDse53U105Idx3tBl6AdjHgisSww/w==}
     engines: {node: '>=18.0.0'}
-    hasBin: true
 
   '@anthropic-ai/sdk@0.63.1':
     resolution: {integrity: sha512-wMA/Xx5GLO+npV992YKUfsmlI6699XG/jFjCPTf/nsMBfUh3e3KmNiOKuhqSMZibOjoLOlhYc7L4pfLPI8A+RA==}
@@ -433,40 +432,34 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-win32-x64@0.33.5':
     resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
@@ -570,67 +563,56 @@ packages:
     resolution: {integrity: sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.3':
     resolution: {integrity: sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.3':
     resolution: {integrity: sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.3':
     resolution: {integrity: sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.3':
     resolution: {integrity: sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.3':
     resolution: {integrity: sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.3':
     resolution: {integrity: sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.3':
     resolution: {integrity: sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.3':
     resolution: {integrity: sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.3':
     resolution: {integrity: sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.3':
     resolution: {integrity: sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.3':
     resolution: {integrity: sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==}
@@ -744,28 +726,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
     resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
     resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.13':
     resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.13':
     resolution: {integrity: sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==}
@@ -2492,28 +2470,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -3885,7 +3859,7 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/claude-code@1.0.128':
+  '@anthropic-ai/claude-agent-sdk@0.1.9':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { ChatViewProvider } from './panels/chatViewProvider';
 import { ClaudeClient } from './services/claude/client';
 import { LogServiceImpl, ConsoleLog, LogLevel } from './services/log/logService';
 import { ClaudeAgentManager } from './services/claude/claude';
-import { ClaudeCodeSessionService, IClaudeCodeSessionService } from './services/claude/session';
+import { ClaudeAgentSessionService, IClaudeAgentSessionService } from './services/claude/session';
 import { InstantiationService, ServiceCollection, IInstantiationService } from './services/common/services';
 import { FileSystemService, IFileSystemService } from './services/filesystem/fileSystemService';
 import { WorkspaceService, IWorkspaceService } from './services/workspace/workspaceService';
@@ -93,7 +93,7 @@ async function initializeServices(context: vscode.ExtensionContext): Promise<voi
   const toolsService = new ToolsService(logService);
 
   // 创建会话服务
-  const sessionService = new ClaudeCodeSessionService(
+  const sessionService = new ClaudeAgentSessionService(
     fileSystemService,
     logService,
     workspaceService,
@@ -109,7 +109,7 @@ async function initializeServices(context: vscode.ExtensionContext): Promise<voi
   serviceCollection.set(INativeEnvService, nativeEnvService);
   serviceCollection.set(IConfigurationService, configService);
   serviceCollection.set(IToolsService, toolsService);
-  serviceCollection.set(IClaudeCodeSessionService, sessionService);
+  serviceCollection.set(IClaudeAgentSessionService, sessionService);
 
   const instantiationService = new InstantiationService(serviceCollection);
 

--- a/src/services/claude/client.ts
+++ b/src/services/claude/client.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IClaudeCodeSessionService } from './session';
+import { IClaudeAgentSessionService } from './session';
 import { ClaudeAgentManager } from './claude';
 import { UiMessageBus } from './uiMessageBus';
 import { UiEvent, ClaudeRequest } from './types';
-import { SDKMessage } from '@anthropic-ai/claude-code';
+import { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import { ILogService } from '../log/logService';
 import type { CancellationToken } from '../common/types';
 
@@ -26,7 +26,7 @@ export class ClaudeClient {
   private currentSessionId?: string;
 
   constructor(
-    private readonly sessionService: IClaudeCodeSessionService,
+    private readonly sessionService: IClaudeAgentSessionService,
     private readonly claudeAgent: ClaudeAgentManager,
     private readonly logService: ILogService
   ) {}

--- a/src/services/claude/session.ts
+++ b/src/services/claude/session.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SDKMessage, SDKUserMessage, SDKUserMessageReplay } from '@anthropic-ai/claude-code';
+import { SDKMessage, SDKUserMessage, SDKUserMessageReplay } from '@anthropic-ai/claude-agent-sdk';
 import Anthropic from '@anthropic-ai/sdk';
 // import type { CancellationToken } from 'vscode';
 import { ResourceMap, ResourceSet } from '../common/map';
@@ -35,19 +35,19 @@ type StoredSDKMessage = SDKMessage & {
 	readonly timestamp: Date;
 }
 
-export const IClaudeCodeSessionService = createServiceIdentifier<IClaudeCodeSessionService>('IClaudeCodeSessionService');
+export const IClaudeAgentSessionService = createServiceIdentifier<IClaudeAgentSessionService>('IClaudeAgentSessionService');
 
-export interface IClaudeCodeSessionService {
-	readonly _serviceBrand: undefined;
-	getAllSessions(token: CancellationToken): Promise<readonly IClaudeCodeSession[]>;
-	getSession(sessionId: string, token: CancellationToken): Promise<IClaudeCodeSession | undefined>;
+export interface IClaudeAgentSessionService {
+        readonly _serviceBrand: undefined;
+        getAllSessions(token: CancellationToken): Promise<readonly IClaudeAgentSession[]>;
+        getSession(sessionId: string, token: CancellationToken): Promise<IClaudeAgentSession | undefined>;
 }
 
-export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
-	declare _serviceBrand: undefined;
+export class ClaudeAgentSessionService implements IClaudeAgentSessionService {
+        declare _serviceBrand: undefined;
 
-	// Simple mtime-based cache
-	private _sessionCache = new ResourceMap<readonly IClaudeCodeSession[]>();
+        // Simple mtime-based cache
+        private _sessionCache = new ResourceMap<readonly IClaudeAgentSession[]>();
 	private _fileMtimes = new ResourceMap<number>();
 
 	constructor(
@@ -65,13 +65,13 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 	 * - Build message chains from leaf nodes
 	 * - These are the complete "sessions" that can be resumed
 	 */
-	async getAllSessions(token: CancellationToken): Promise<readonly IClaudeCodeSession[]> {
-		const folders = this._workspace.getWorkspaceFolders();
-		const items: IClaudeCodeSession[] = [];
+        async getAllSessions(token: CancellationToken): Promise<readonly IClaudeAgentSession[]> {
+                const folders = this._workspace.getWorkspaceFolders();
+                const items: IClaudeAgentSession[] = [];
 
 		// 如果没有工作区文件夹，直接返回空数组
 		if (folders.length === 0) {
-			this._logService.debug('[ClaudeCodeSessionService] 没有工作区文件夹，返回空会话列表');
+                        this._logService.debug('[ClaudeAgentSessionService] 没有工作区文件夹，返回空会话列表');
 			return items;
 		}
 
@@ -99,15 +99,15 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 		return items;
 	}
 
-	async getSession(claudeCodeSessionId: string, token: CancellationToken): Promise<IClaudeCodeSession | undefined> {
-		const all = await this.getAllSessions(token);
-		return all.find(session => session.id === claudeCodeSessionId);
-	}
+        async getSession(claudeAgentSessionId: string, token: CancellationToken): Promise<IClaudeAgentSession | undefined> {
+                const all = await this.getAllSessions(token);
+                return all.find(session => session.id === claudeAgentSessionId);
+        }
 
 	/**
 	 * Check if cached sessions are still valid by comparing file modification times
 	 */
-	private async _getCachedSessionsIfValid(projectDirUri: URI, token: CancellationToken): Promise<readonly IClaudeCodeSession[] | null> {
+        private async _getCachedSessionsIfValid(projectDirUri: URI, token: CancellationToken): Promise<readonly IClaudeAgentSession[] | null> {
 		if (!this._sessionCache.has(projectDirUri)) {
 			return null; // No cache entry
 		}
@@ -157,7 +157,7 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 			return this._sessionCache.get(projectDirUri) || null;
 		} catch (e) {
 			// Directory read failed, invalidate cache
-			this._logService.error(e as Error, `[ClaudeCodeSessionLoader] Failed to check cache validity for: ${projectDirUri}`);
+                        this._logService.error(e as Error, `[ClaudeAgentSessionLoader] Failed to check cache validity for: ${projectDirUri}`);
 			return null;
 		}
 	}
@@ -165,7 +165,7 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 	/**
 	 * Load sessions from disk and update file modification time tracking
 	 */
-	private async _loadSessionsFromDisk(projectDirUri: URI, token: CancellationToken): Promise<readonly IClaudeCodeSession[]> {
+        private async _loadSessionsFromDisk(projectDirUri: URI, token: CancellationToken): Promise<readonly IClaudeAgentSession[]> {
 		let entries: [string, FileType][] = [];
 		try {
 			entries = await this._fileSystem.readDirectory(projectDirUri);
@@ -231,7 +231,7 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 			}
 		}
 
-		const sessions: IClaudeCodeSession[] = [];
+            const sessions: IClaudeAgentSession[] = [];
 		for (const leafUuid of leafNodes) {
 			const messages: StoredSDKMessage[] = [];
 			let currentUuid: string | null = leafUuid;
@@ -253,7 +253,7 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 
 			// Create session if we have messages
 			if (messages.length > 0) {
-				const session: IClaudeCodeSession = {
+                            const session: IClaudeAgentSession = {
 					id: allMessages.get(leafUuid)!.sessionId,
 					label: this._generateSessionLabel(summaryEntry, messages),
 					messages: messages,
@@ -264,7 +264,7 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 		}
 
 		// De-duplicate by SDK session id: keep the most recent conversation per sessionId
-		const byId = new Map<string, IClaudeCodeSession>();
+            const byId = new Map<string, IClaudeAgentSession>();
 		for (const s of sessions) {
 			const existing = byId.get(s.id);
 			if (!existing) {
@@ -422,9 +422,9 @@ export class ClaudeCodeSessionService implements IClaudeCodeSessionService {
 
 }
 
-export interface IClaudeCodeSession {
-	readonly id: string;
-	readonly label: string;
-	readonly messages: readonly SDKMessage[];
-	readonly timestamp: Date;
+export interface IClaudeAgentSession {
+        readonly id: string;
+        readonly label: string;
+        readonly messages: readonly SDKMessage[];
+        readonly timestamp: Date;
 }

--- a/src/services/claude/types.ts
+++ b/src/services/claude/types.ts
@@ -14,7 +14,7 @@ import type {
   SDKSystemMessage,
   SDKUserMessage,
   SDKUserMessageReplay,
-} from '@anthropic-ai/claude-code';
+} from '@anthropic-ai/claude-agent-sdk';
 
 // 供 UI 使用的消息事件总线类型（仅数据透传与轻量增强）
 

--- a/src/services/configuration/configurationService.ts
+++ b/src/services/configuration/configurationService.ts
@@ -18,7 +18,7 @@ export interface IConfigurationService {
 // 配置键定义，基于原始 ConfigKey namespace
 export namespace ConfigKey {
 	export namespace Internal {
-		export const ClaudeCodeDebugEnabled = 'chat.advanced.claudeCode.debug';
+                export const ClaudeAgentDebugEnabled = 'chat.advanced.claudeAgent.debug';
 		export const AgentTemperature = 'chat.advanced.agent.temperature';
 	}
 }
@@ -27,7 +27,7 @@ export class ConfigurationService implements IConfigurationService {
 	declare _serviceBrand: undefined;
 
 	private config = new Map<string, any>([
-		[ConfigKey.Internal.ClaudeCodeDebugEnabled, false],
+                [ConfigKey.Internal.ClaudeAgentDebugEnabled, false],
 		[ConfigKey.Internal.AgentTemperature, 0],
 		['chat.agent.maxRequests', 50]
 	]);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,6 +1,6 @@
 // 全局类型声明
 
-// 修复 @anthropic-ai/claude-code SDK 中缺失的 Dict 类型
+// 修复 @anthropic-ai/claude-agent-sdk 中缺失的 Dict 类型
 declare global {
   type Dict<T = any> = Record<string, T>;
 }

--- a/webview/src/services/messageBus.ts
+++ b/webview/src/services/messageBus.ts
@@ -13,7 +13,7 @@ import type {
   PermissionState
 } from '../../types/messages';
 import type { QueuedMessage, MessageQueueState } from '../../types/queue';
-import type { SDKMessage } from '@anthropic-ai/claude-code';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import {
   extractTextContent,
   extractContentBlocks,

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -10,7 +10,7 @@ import type {
   SDKSystemMessage,
   SDKCompactBoundaryMessage,
   SDKPartialAssistantMessage
-} from '@anthropic-ai/claude-code';
+} from '@anthropic-ai/claude-agent-sdk';
 
 // 内容块类型定义
 export interface ContentBlock {

--- a/webview/types/messages.ts
+++ b/webview/types/messages.ts
@@ -11,7 +11,7 @@ import type {
   SDKSystemMessage,
   SDKPartialAssistantMessage,
   SDKCompactBoundaryMessage
-} from '@anthropic-ai/claude-code';
+} from '@anthropic-ai/claude-agent-sdk';
 
 // VSCode API接口
 export interface VSCodeAPI {


### PR DESCRIPTION
## Summary
- replace the Claude Code dependency with the new `@anthropic-ai/claude-agent-sdk` and update build tooling to copy the Agent CLI
- update backend services to use Claude Agent naming, configuration keys, and imports while preserving session management
- align webview message types and utilities with the Claude Agent SDK exports

## Testing
- pnpm run check-types

------
https://chatgpt.com/codex/tasks/task_b_68e4d4dac1688331b26694b566ab380f